### PR TITLE
Fix pasting in tables

### DIFF
--- a/lib/handlers/onPaste.js
+++ b/lib/handlers/onPaste.js
@@ -21,32 +21,9 @@ function onPaste(
         return next();
     }
 
-    const transfer = getEventTransfer(event);
-    const { type, fragment } = transfer;
-
-    if (type != 'fragment' || fragment.nodes.isEmpty()) {
-        return null;
-    }
-
-    if (
-        !isRangeInTable(
-            opts,
-            fragment,
-            Range.create({
-                anchorKey: fragment.getFirstText().key,
-                focusKey: fragment.getLastText().key
-            })
-        )
-    ) {
-        return null;
-    }
-
-    return insertTableFragmentAtRange(
-        opts,
-        editor,
-        editor.value.selection,
-        fragment
-    );
+    const text = getEventTransfer(event).text;
+    editor.insertText(text);
+    return null
 }
 
 export default onPaste;


### PR DESCRIPTION
Edit onPaste handler to only paste text

> Fixes issue with not being able to paste into the table
> Also fixes issue in which table functionality would break after slate fragments were pasted into cells